### PR TITLE
Feature/rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
@@ -94,6 +93,11 @@
 			<groupId>net.devh</groupId>
 			<artifactId>grpc-server-spring-boot-starter</artifactId>
 			<version>3.1.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/backend/test/coffee_roasting/CoffeeRoastingApplication.java
+++ b/src/main/java/backend/test/coffee_roasting/CoffeeRoastingApplication.java
@@ -1,11 +1,14 @@
 package backend.test.coffee_roasting;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "Coffee roasting microservice", version = "1.0.0",
+		description = "Microservice for managing coffee roasting "))
 public class CoffeeRoastingApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(CoffeeRoastingApplication.class, args);
 	}

--- a/src/main/java/backend/test/coffee_roasting/controller/GrainStockController.java
+++ b/src/main/java/backend/test/coffee_roasting/controller/GrainStockController.java
@@ -1,0 +1,26 @@
+package backend.test.coffee_roasting.controller;
+
+import backend.test.coffee_roasting.service.GrainStockService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/grain_stock")
+@Tag(name = "Grain stock", description = "Endpoints for grain stock information")
+public class GrainStockController {
+    private GrainStockService grainStockService;
+
+    @GetMapping("/available")
+    public ResponseEntity<Double> getAvailableWeightGrams(
+            @Parameter(description = "Origin country for coffee")
+            @RequestParam(value = "originCountry", required = false) String originCountry,
+
+            @Parameter(description = "Coffee grain type")
+            @RequestParam(value = "grainType", required = false) String grainType) {
+        return ResponseEntity.ok(grainStockService.getAvailableWeightGrams(originCountry, grainType));
+    }
+}

--- a/src/main/java/backend/test/coffee_roasting/controller/RoastingLossController.java
+++ b/src/main/java/backend/test/coffee_roasting/controller/RoastingLossController.java
@@ -1,0 +1,31 @@
+package backend.test.coffee_roasting.controller;
+
+import backend.test.coffee_roasting.service.RoastingLossService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/roasting_loss")
+@Tag(name = "Roasting loss", description = "Endpoints for roasting loss information")
+public class RoastingLossController {
+    private RoastingLossService roastingLossService;
+
+    @GetMapping
+    public ResponseEntity<Double> getLossPercentage(
+            @Parameter(description = "Unique identifier of brigade")
+            @RequestParam(value = "brigadeId", required = false) UUID brigadeId,
+
+            @Parameter(description = "Origin country for coffee")
+            @RequestParam(value = "originCountry", required = false) String originCountry) {
+        return ResponseEntity.ok(roastingLossService.getLossPercentage(brigadeId, originCountry));
+    }
+}

--- a/src/main/java/backend/test/coffee_roasting/data/entity/GrainStock.java
+++ b/src/main/java/backend/test/coffee_roasting/data/entity/GrainStock.java
@@ -1,0 +1,26 @@
+package backend.test.coffee_roasting.data.entity;
+
+import backend.test.coffee_roasting.data.entity.pk.GrainStockPK;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "grain_stock")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@IdClass(GrainStockPK.class)
+public class GrainStock {
+    @Id
+    @Column(name = "grain_type", nullable = false)
+    private String grainType;
+    @Id
+    @Column(name = "origin_country", nullable = false)
+    private String originCountry;
+    @Column(name = "available_weight_grams")
+    private double availableWeightGrams;
+}

--- a/src/main/java/backend/test/coffee_roasting/data/entity/pk/GrainStockPK.java
+++ b/src/main/java/backend/test/coffee_roasting/data/entity/pk/GrainStockPK.java
@@ -1,0 +1,17 @@
+package backend.test.coffee_roasting.data.entity.pk;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GrainStockPK implements Serializable {
+    private String grainType;
+    private String originCountry;
+}

--- a/src/main/java/backend/test/coffee_roasting/data/mapper/GrainIntakeMapper.java
+++ b/src/main/java/backend/test/coffee_roasting/data/mapper/GrainIntakeMapper.java
@@ -12,7 +12,7 @@ public class GrainIntakeMapper {
         GrainIntake grainIntake = new GrainIntake();
 
         double weightGrams = grainIntakeMessage.getNumberOfBags() * BAG_WEIGHT_KILOGRAMS * 1000;
-        grainIntake.setOriginCountry(grainIntakeMessage.getCountryOfOrigin());
+        grainIntake.setOriginCountry(grainIntakeMessage.getOriginCountry());
         grainIntake.setGrainType(grainIntakeMessage.getGrainType());
         grainIntake.setRobustaPercentage(grainIntakeMessage.getRobustaPercentage());
         grainIntake.setArabicaPercentage(grainIntakeMessage.getArabicaPercentage());

--- a/src/main/java/backend/test/coffee_roasting/data/mapper/GrainStockMapper.java
+++ b/src/main/java/backend/test/coffee_roasting/data/mapper/GrainStockMapper.java
@@ -1,0 +1,18 @@
+package backend.test.coffee_roasting.data.mapper;
+
+import backend.test.coffee_roasting.data.entity.GrainIntake;
+import backend.test.coffee_roasting.data.entity.GrainStock;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GrainStockMapper {
+    public GrainStock grainIntakeToGrainStock(GrainIntake grainIntake) {
+        GrainStock grainStock = new GrainStock();
+
+        grainStock.setGrainType(grainIntake.getGrainType());
+        grainStock.setOriginCountry(grainIntake.getOriginCountry());
+        grainStock.setAvailableWeightGrams(grainIntake.getWeightGrams());
+
+        return grainStock;
+    }
+}

--- a/src/main/java/backend/test/coffee_roasting/data/message/GrainIntakeMessage.java
+++ b/src/main/java/backend/test/coffee_roasting/data/message/GrainIntakeMessage.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Setter
 @ToString
 public class GrainIntakeMessage {
-    private String countryOfOrigin;
+    private String originCountry;
     private String grainType;
     private double robustaPercentage;
     private double arabicaPercentage;

--- a/src/main/java/backend/test/coffee_roasting/data/repository/GrainStockRepository.java
+++ b/src/main/java/backend/test/coffee_roasting/data/repository/GrainStockRepository.java
@@ -1,0 +1,16 @@
+package backend.test.coffee_roasting.data.repository;
+
+import backend.test.coffee_roasting.data.entity.GrainStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@EnableJpaRepositories
+public interface GrainStockRepository extends JpaRepository<GrainStock, Long> {
+    List<GrainStock> findByOriginCountryAndGrainType(String originCountry, String grainType);
+    List<GrainStock> findByOriginCountry(String originCountry);
+    List<GrainStock> findByGrainType(String grainType);
+}

--- a/src/main/java/backend/test/coffee_roasting/data/repository/RoastingOuttakeRepository.java
+++ b/src/main/java/backend/test/coffee_roasting/data/repository/RoastingOuttakeRepository.java
@@ -5,7 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.UUID;
+
 @EnableJpaRepositories
 @Repository
 public interface RoastingOuttakeRepository extends JpaRepository<RoastingOuttake, Long> {
+    List<RoastingOuttake> findByOriginCountryAndBrigadeId(String originCountry, UUID brigadeId);
+    List<RoastingOuttake> findByOriginCountry(String originCountry);
+    List<RoastingOuttake> findByBrigadeId(UUID brigadeId);
 }

--- a/src/main/java/backend/test/coffee_roasting/service/GrainIntakeService.java
+++ b/src/main/java/backend/test/coffee_roasting/service/GrainIntakeService.java
@@ -1,24 +1,45 @@
 package backend.test.coffee_roasting.service;
 
+import backend.test.coffee_roasting.data.entity.GrainIntake;
+import backend.test.coffee_roasting.data.entity.GrainStock;
 import backend.test.coffee_roasting.data.mapper.GrainIntakeMapper;
+import backend.test.coffee_roasting.data.mapper.GrainStockMapper;
 import backend.test.coffee_roasting.data.repository.GrainIntakeRepository;
 import backend.test.coffee_roasting.data.message.GrainIntakeMessage;
+import backend.test.coffee_roasting.data.repository.GrainStockRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @AllArgsConstructor
 @Slf4j
 public class GrainIntakeService {
     private GrainIntakeRepository grainIntakeRepository;
+    private GrainStockRepository grainStockRepository;
     private GrainIntakeMapper grainIntakeMapper;
+    private GrainStockMapper grainStockMapper;
 
     @KafkaListener(topics = "grain-intake", groupId = "grain-consumers",
             containerFactory = "grainListenerContainerFactory")
     public void addGrainIntake(GrainIntakeMessage grainIntakeMessage) {
         log.info("Received Grain Intake message: {}", grainIntakeMessage);
-        grainIntakeRepository.save(grainIntakeMapper.messageToEntity(grainIntakeMessage));
+        GrainIntake grainIntake = grainIntakeMapper.messageToEntity(grainIntakeMessage);
+        grainIntakeRepository.save(grainIntake);
+
+        List<GrainStock> existingStock = grainStockRepository.findByOriginCountryAndGrainType(
+                grainIntake.getOriginCountry(),
+                grainIntake.getGrainType());
+
+        if (existingStock!= null && !existingStock.isEmpty() && existingStock.get(0) != null) {
+            GrainStock grainStock = existingStock.get(0);
+            grainStock.setAvailableWeightGrams(grainStock.getAvailableWeightGrams() + grainIntake.getWeightGrams());
+            grainStockRepository.save(grainStock);
+        } else {
+            grainStockRepository.save(grainStockMapper.grainIntakeToGrainStock(grainIntake));
+        }
     }
 }

--- a/src/main/java/backend/test/coffee_roasting/service/GrainStockService.java
+++ b/src/main/java/backend/test/coffee_roasting/service/GrainStockService.java
@@ -1,0 +1,32 @@
+package backend.test.coffee_roasting.service;
+
+import backend.test.coffee_roasting.data.entity.GrainStock;
+import backend.test.coffee_roasting.data.repository.GrainStockRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Service
+public class GrainStockService {
+    private GrainStockRepository grainStockRepository;
+
+    public Double getAvailableWeightGrams(String originCountry, String grainType) {
+        List<GrainStock> grainStocks;
+
+        if (originCountry != null && grainType != null) {
+            grainStocks = grainStockRepository.findByOriginCountryAndGrainType(originCountry, grainType);
+        } else if (originCountry != null) {
+            grainStocks = grainStockRepository.findByOriginCountry(originCountry);
+        } else if (grainType != null) {
+            grainStocks = grainStockRepository.findByGrainType(grainType);
+        } else {
+            grainStocks = grainStockRepository.findAll();
+        }
+
+        return grainStocks.stream()
+                .mapToDouble(GrainStock::getAvailableWeightGrams)
+                .sum();
+    }
+}

--- a/src/main/java/backend/test/coffee_roasting/service/RoastingLossService.java
+++ b/src/main/java/backend/test/coffee_roasting/service/RoastingLossService.java
@@ -1,0 +1,33 @@
+package backend.test.coffee_roasting.service;
+
+import backend.test.coffee_roasting.data.entity.RoastingOuttake;
+import backend.test.coffee_roasting.data.repository.RoastingOuttakeRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@AllArgsConstructor
+public class RoastingLossService {
+    private RoastingOuttakeRepository roastingOuttakeRepository;
+
+    public Double getLossPercentage(UUID brigadeId, String originCountry) {
+        List<RoastingOuttake> grainStocks;
+
+        if (originCountry != null && brigadeId != null) {
+            grainStocks = roastingOuttakeRepository.findByOriginCountryAndBrigadeId(originCountry, brigadeId);
+        } else if (originCountry != null) {
+            grainStocks = roastingOuttakeRepository.findByOriginCountry(originCountry);
+        } else if (brigadeId != null) {
+            grainStocks = roastingOuttakeRepository.findByBrigadeId(brigadeId);
+        } else {
+            grainStocks = roastingOuttakeRepository.findAll();
+        }
+
+        return grainStocks.stream()
+                .mapToDouble(RoastingOuttake::getLossPercentage)
+                .sum();
+    }
+}

--- a/src/main/java/backend/test/coffee_roasting/service/RoastingOuttakeServiceImpl.java
+++ b/src/main/java/backend/test/coffee_roasting/service/RoastingOuttakeServiceImpl.java
@@ -1,30 +1,65 @@
 package backend.test.coffee_roasting.service;
 
+import backend.test.coffee_roasting.data.entity.GrainStock;
 import backend.test.coffee_roasting.data.mapper.RoastingOuttakeMapper;
+import backend.test.coffee_roasting.data.repository.GrainStockRepository;
 import backend.test.coffee_roasting.data.repository.RoastingOuttakeRepository;
 import backend.test.coffee_roasting.grpc.roasting_outtake.RoastingOuttakeRequest;
 import backend.test.coffee_roasting.grpc.roasting_outtake.RoastingOuttakeResponse;
 import backend.test.coffee_roasting.grpc.roasting_outtake.RoastingServiceGrpc;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.service.GrpcService;
+
+import java.util.List;
 
 @Slf4j
 @GrpcService
 @AllArgsConstructor
 public class RoastingOuttakeServiceImpl extends RoastingServiceGrpc.RoastingServiceImplBase {
     private RoastingOuttakeRepository roastingOuttakeRepository;
+    private GrainStockRepository grainStockRepository;
     private RoastingOuttakeMapper roastingOuttakeMapper;
 
     @Override
     public void addRoastingOuttake(RoastingOuttakeRequest roastingOuttakeRequest,
                                    StreamObserver<RoastingOuttakeResponse> responseObserver) {
         log.info("Received Roasting Outtake request: {}", roastingOuttakeRequest);
+
+        String grainType = roastingOuttakeRequest.getGrainType();
+        String originCountry = roastingOuttakeRequest.getOriginCountry();
+        double inputWeightGrams = roastingOuttakeRequest.getInputWeightGrams();
+
+        List<GrainStock> existingStock = grainStockRepository.findByOriginCountryAndGrainType(originCountry, grainType);
+
+        if (existingStock == null || existingStock.isEmpty() || existingStock.get(0) == null) {
+            StatusRuntimeException exception = Status.INVALID_ARGUMENT
+                    .withDescription("No stock available for specified grain type and origin country.")
+                    .asRuntimeException();
+            responseObserver.onError(exception);
+            return;
+        }
+
+        GrainStock grainStock = existingStock.get(0);
+
+        if (grainStock.getAvailableWeightGrams() < inputWeightGrams) {
+            StatusRuntimeException exception = Status.INVALID_ARGUMENT
+                    .withDescription("Not enough grain available for roasting.")
+                    .asRuntimeException();
+            responseObserver.onError(exception);
+            return;
+        }
+
+        grainStock.setAvailableWeightGrams(grainStock.getAvailableWeightGrams() - inputWeightGrams);
+        grainStockRepository.save(grainStock);
+
         roastingOuttakeRepository.save(roastingOuttakeMapper.requestToEntity(roastingOuttakeRequest));
 
         RoastingOuttakeResponse roastingOuttakeResponse = RoastingOuttakeResponse.newBuilder()
-                .setMessage("Roasting outtake information saved successfully.")
+                .setMessage("Roasting outtake information received successfully.")
                 .build();
 
         responseObserver.onNext(roastingOuttakeResponse);


### PR DESCRIPTION
**Summary:**
This PR adds a REST API to retrieve grain stock levels by type and country with filtering capabilities, as well as roasting loss information by brigade and country of origin. Swagger is also integrated for API documentation.

**Key Changes:**
- Added endpoints to get grain stock with filters (originCountry, grainType).
- Created GrainStock entity and repository for stock management.
- Added endpoints for brigade loss percentages and country-specific loss calculations.
- Integrated Swagger for API documentation and testing.